### PR TITLE
Update the php namespace to match the folder structure. 

### DIFF
--- a/source/src/Controllers/Middleware.php
+++ b/source/src/Controllers/Middleware.php
@@ -11,8 +11,8 @@ namespace Adknown\ProxyScalyr\Controllers;
 use Adknown\ProxyScalyr\Grafana\Response\Query\TimeSeriesTarget;
 use Adknown\ProxyScalyr\Scalyr\ComplexExpressions\Parser;
 use Adknown\ProxyScalyr\Scalyr\Request\Numeric;
-use Adknown\ProxyScalyr\Scalyr\ScalyrResponse\FacetResponse;
-use Adknown\ProxyScalyr\Scalyr\ScalyrResponse\NumericResponse;
+use Adknown\ProxyScalyr\Scalyr\Response\FacetResponse;
+use Adknown\ProxyScalyr\Scalyr\Response\NumericResponse;
 use Adknown\ProxyScalyr\Scalyr\SDK;
 use Exception;
 

--- a/source/src/Scalyr/ComplexExpressions/Parser.php
+++ b/source/src/Scalyr/ComplexExpressions/Parser.php
@@ -10,7 +10,7 @@ namespace Adknown\ProxyScalyr\Scalyr\ComplexExpressions;
 
 use Adknown\ProxyScalyr\Logging\LoggerImpl;
 use Adknown\ProxyScalyr\Scalyr\Request\Numeric;
-use Adknown\ProxyScalyr\Scalyr\ScalyrResponse\NumericResponse;
+use Adknown\ProxyScalyr\Scalyr\Response\NumericResponse;
 
 class Parser
 {

--- a/source/src/Scalyr/Response/FacetResponse.php
+++ b/source/src/Scalyr/Response/FacetResponse.php
@@ -6,7 +6,7 @@
  * Time: 13:24
  */
 
-namespace Adknown\ProxyScalyr\Scalyr\ScalyrResponse;
+namespace Adknown\ProxyScalyr\Scalyr\Response;
 
 
 class FacetResponse extends aResponse

--- a/source/src/Scalyr/Response/NumericResponse.php
+++ b/source/src/Scalyr/Response/NumericResponse.php
@@ -6,7 +6,7 @@
  * Time: 11:56
  */
 
-namespace Adknown\ProxyScalyr\Scalyr\ScalyrResponse;
+namespace Adknown\ProxyScalyr\Scalyr\Response;
 
 
 class NumericResponse extends aResponse

--- a/source/src/Scalyr/Response/aResponse.php
+++ b/source/src/Scalyr/Response/aResponse.php
@@ -6,7 +6,7 @@
  * Time: 11:54
  */
 
-namespace Adknown\ProxyScalyr\Scalyr\ScalyrResponse;
+namespace Adknown\ProxyScalyr\Scalyr\Response;
 
 
 abstract class aResponse

--- a/source/src/Scalyr/SDK.php
+++ b/source/src/Scalyr/SDK.php
@@ -10,8 +10,8 @@ namespace Adknown\ProxyScalyr\Scalyr;
 
 
 use Adknown\ProxyScalyr\Scalyr\Request\Numeric;
-use Adknown\ProxyScalyr\Scalyr\ScalyrResponse\FacetResponse;
-use Adknown\ProxyScalyr\Scalyr\ScalyrResponse\NumericResponse;
+use Adknown\ProxyScalyr\Scalyr\Response\FacetResponse;
+use Adknown\ProxyScalyr\Scalyr\Response\NumericResponse;
 use \Exception;
 use GuzzleHttp\Client;
 


### PR DESCRIPTION
This fixes NumericResponse class not found errors.