### PR TITLE
feat(CLV-40): Add backend server support for fixed intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 source/vendor/
+package/
 docker-container/scalyr/agent.d/api_key.json
 docker-container/.env

--- a/source/src/Controllers/Middleware.php
+++ b/source/src/Controllers/Middleware.php
@@ -8,7 +8,9 @@
 
 namespace Adknown\ProxyScalyr\Controllers;
 
+use Adknown\ProxyScalyr\Grafana\Request\Target;
 use Adknown\ProxyScalyr\Grafana\Response\Query\TimeSeriesTarget;
+use Adknown\ProxyScalyr\Logging\LoggerImpl;
 use Adknown\ProxyScalyr\Scalyr\ComplexExpressions\Parser;
 use Adknown\ProxyScalyr\Scalyr\Request\Numeric;
 use Adknown\ProxyScalyr\Scalyr\Response\FacetResponse;
@@ -51,18 +53,89 @@ class Middleware
 				throw new Exception("'type' must defined as one of: " . implode("','", self::QUERY_TYPES));
 			}
 
-			if (empty($queryData->target))
+			if(empty($queryData->target))
 			{
 				throw new Exception(sprintf("Empty target found for query #%d. All queries must have a target.", $targetIndex + 1));
 			}
-
-			$start = strtotime($request->range->from);
-			$end = strtotime($request->range->to);
+			$start = $request->range->GetFromAsTimestamp();
+			$end = $request->range->GetToAsTimestamp();
 			$buckets = $this->CalculateBuckets($start, $end, $queryData->secondsInterval);
 
 			switch($queryData->type)
 			{
 				case 'numeric query':
+					//split the query into complete intervals
+					if($queryData->intervalType === Target::INTERVAL_TYPE_FIXED)
+					{
+						$startDT = new \DateTime($request->range->from, new \DateTimeZone('utc'));
+						$endDT = new \DateTime($request->range->to, new \DateTimeZone('utc'));
+						switch($queryData->chosenType)
+						{
+							case Target::FIXED_INTERVAL_MINUTE:
+								$startDT->setTime(
+									(int)$startDT->format('H'),
+									(int)$startDT->format('i'),
+									0
+								);
+								$endDT->setTime(
+									(int)$endDT->format('H'),
+									(int)$endDT->format('i'),
+									0
+								);
+								$queryData->secondsInterval = 60;
+								break;
+							case Target::FIXED_INTERVAL_HOUR:
+								$startDT->setTime(
+									(int)$startDT->format('H'),
+									0,
+									0
+								);
+								$endDT->setTime(
+									(int)$endDT->format('H'),
+									0,
+									0
+								);
+								$queryData->secondsInterval = 3600;
+								break;
+							case Target::FIXED_INTERVAL_DAY:
+								$startDT->setTime(
+									0,
+									0,
+									0
+								);
+								$endDT->setTime(
+									0,
+									0,
+									0
+								);
+								$queryData->secondsInterval = 86400;
+								break;
+							case Target::FIXED_INTERVAL_WEEK:
+							case Target::FIXED_INTERVAL_MONTH:
+							default:
+								throw new Exception("Selection '{$queryData->chosenType}' Not yet implemented");
+						}
+
+						$startRemainder = $endDT->getTimestamp();
+						$endRemainder = $end;
+						$bucketsRemainder = 1;
+						$remainderResponse = $this->api->NumericQuery(
+							new Numeric(
+								$queryData->filter,
+								$queryData->graphFunction,
+								!empty($queryData->expression) ? $queryData->expression : '',
+								$startRemainder,
+								$endRemainder,
+								$bucketsRemainder
+							)
+						);
+
+						$start = $startDT->getTimestamp();
+						$end = $endDT->getTimestamp();
+						$buckets = $this->CalculateBuckets($start, $end, $queryData->secondsInterval);
+					}
+
+
 					$response = $this->api->NumericQuery(
 						new Numeric(
 							$queryData->filter,
@@ -74,6 +147,12 @@ class Middleware
 						)
 					);
 
+					if(isset($remainderResponse))
+					{
+						$response->values = array_merge($response->values, $remainderResponse->values);
+						unset($remainderResponse);
+					}
+
 					$grafResponse->AddTarget($this->ConvertScalyrNumericToGrafana($response, $queryData->target, $start, $queryData->secondsInterval));
 					break;
 
@@ -82,12 +161,11 @@ class Middleware
 					$simpleExpressions = Parser::ParseComplexExpression($queryData->filter, $start, $end, $buckets, $fullVariableExpression);
 					foreach($simpleExpressions as $key => $scalyrParams)
 					{
-						if ($scalyrParams instanceof Numeric)
+						if($scalyrParams instanceof Numeric)
 						{
 							$response = $this->api->NumericQuery($scalyrParams);
 							$simpleExpressions[$key] = $response;
 						}
-
 					}
 					$fullResponse = Parser::NewEvaluateExpression($fullVariableExpression, $simpleExpressions);
 					$grafResponse->AddTarget($this->ConvertScalyrNumericToGrafana($fullResponse, $queryData->target, $start, $queryData->secondsInterval));

--- a/source/src/Controllers/Middleware.php
+++ b/source/src/Controllers/Middleware.php
@@ -104,7 +104,7 @@ class Middleware
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\TimeSeries $request
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\Target $queryData
 	 *
-	 * @return TimeSeriesTarget - The target to sent via the Grafana response
+	 * @return TimeSeriesTarget - The target to send in the Grafana response
 	 * @throws Exception - Numeric bucket limit reached
 	 */
 	private function GetNumericQueryTarget($request, $queryData)
@@ -170,7 +170,7 @@ class Middleware
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\TimeSeries $request
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\Target $queryData
 	 *
-	 * @return TimeSeriesTarget - The target to sent via the Grafana response
+	 * @return TimeSeriesTarget - The target to send in the Grafana response
 	 * @throws Exception - Numeric bucket limit reached
 	 */
 	private function GetComplexQueryTarget($request, $queryData)

--- a/source/src/Controllers/Middleware.php
+++ b/source/src/Controllers/Middleware.php
@@ -69,6 +69,7 @@ class Middleware
 	 *
 	 * @return float - The Scalyr datapoint value representing the interval [roundendEnd, end]
 	 * @throws \GuzzleHttp\Exception\GuzzleException
+	 * @throws \Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException
 	 */
 	private function GetScalyrNumericRemainder($queryData, $roundedEnd, $end)
 	{
@@ -84,6 +85,7 @@ class Middleware
 	 *
 	 * @return NumericResponse - A Scalyr numeric response contain X datapoints, where X == $buckets
 	 * @throws \GuzzleHttp\Exception\GuzzleException
+	 * @throws \Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException
 	 */
 	private function GetScalyrNumericResponse($queryData, $start, $end, $buckets)
 	{
@@ -104,7 +106,7 @@ class Middleware
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\Target     $queryData
 	 *
 	 * @return TimeSeriesTarget - The target to send in the Grafana response
-	 * @throws \Exception - Numeric bucket limit reached
+	 * @throws \Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
 	private function GetNumericQueryTarget($request, $queryData)
@@ -196,7 +198,7 @@ class Middleware
 	 * @param \Adknown\ProxyScalyr\Grafana\Request\TimeSeries $request
 	 *
 	 * @return \Adknown\ProxyScalyr\Grafana\Response\Query\TimeSeries
-	 * @throws \Exception - Numeric bucket limit reached
+	 * @throws \Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
 	public function GrafanaToScalyrQuery(\Adknown\ProxyScalyr\Grafana\Request\TimeSeries $request)

--- a/source/src/Controllers/Query.php
+++ b/source/src/Controllers/Query.php
@@ -50,6 +50,12 @@ class Query extends Ajax
 			$message = !empty($resparray['message']) ? $resparray['message'] : "Unable to get the error message from scalyr";
 			$this->RespondError($message);
 		}
+		catch (\Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException $ex)
+		{
+			LoggerImpl::Exception($ex);
+			$message = "Selected time interval too small for selected time range. Logic to make multiple Scalyr requests to get the required data points not yet implementeed. " . $ex->getMessage();
+			$this->RespondError($message);
+		}
 	}
 
 	protected function Delete()

--- a/source/src/Grafana/Request/Range.php
+++ b/source/src/Grafana/Request/Range.php
@@ -13,4 +13,26 @@ class Range
 {
 	public $from;
 	public $to;
+
+	/**
+	 * Returns the unix timestamp equivalent of the set $from string
+	 *
+	 * @return false|int
+	 */
+	public function GetFromAsTimestamp()
+	{
+		return strtotime($this->from);
+	}
+
+	/**
+	 * Returns the unix timestamp equivalent of the set $to string
+	 *
+	 * @return false|int
+	 */
+	public function GetToAsTimestamp()
+	{
+		return strtotime($this->to);
+	}
+
+
 }

--- a/source/src/Grafana/Request/Target.php
+++ b/source/src/Grafana/Request/Target.php
@@ -11,6 +11,15 @@ namespace Adknown\ProxyScalyr\Grafana\Request;
 
 class Target
 {
+	const INTERVAL_TYPE_FIXED = 'fixed';
+	const INTERVAL_TYPE_WINDOW = 'window';
+
+	const FIXED_INTERVAL_MINUTE = 'minute';
+	const FIXED_INTERVAL_HOUR = 'hour';
+	const FIXED_INTERVAL_DAY = 'day';
+	const FIXED_INTERVAL_WEEK = 'week';
+	const FIXED_INTERVAL_MONTH = 'month';
+
 	//all fields are assumed to be strings unless otherwise annotated
 	public $filter;
 	public $graphFunction;
@@ -28,8 +37,17 @@ class Target
 	 * @var int
 	 */
 	public $secondsInterval;
+	/**
+	 * @var string The type of interval used in this time series.
+	 * Possible Values: 'fixed', 'window'
+	 */
+	public $intervalType;
+
+	/**
+	 * @var string The chosen interval type, only relevant when the user has selected 'fixed' for interval type
+	 */
+	public $chosenType;
 	public $target;
 	public $type;
 	public $expression;
-
 }

--- a/source/src/Grafana/Request/TimeSeriesTransformer.php
+++ b/source/src/Grafana/Request/TimeSeriesTransformer.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * Created by PhpStorm.
+ *
+ * Used by the JSON decoder library: karriere/json-decoder
+ *
  * User: matt
  * Date: 06/07/18
  * Time: 5:49 PM

--- a/source/src/Grafana/Response/Query/TimeSeriesTarget.php
+++ b/source/src/Grafana/Response/Query/TimeSeriesTarget.php
@@ -21,6 +21,14 @@ class TimeSeriesTarget
 	 */
 	public $datapoints;
 
+	/**
+	 * @param float $value - The value of the datapoint
+	 * @param int $time - The timestamp of the datapoint, in seconds
+	 */
+	public function Append($value, $time) {
+		$this->datapoints[] = [$value, $time * 1000];
+	}
+
 	public function __construct(?string $target, array $datapoints)
 	{
 		$this->target = $target;

--- a/source/src/Grafana/Response/Query/TimeSeriesTarget.php
+++ b/source/src/Grafana/Response/Query/TimeSeriesTarget.php
@@ -22,6 +22,8 @@ class TimeSeriesTarget
 	public $datapoints;
 
 	/**
+	 * Multiplies $time by 1000 to convert it into milliseconds
+	 *
 	 * @param float $value - The value of the datapoint
 	 * @param int $time - The timestamp of the datapoint, in seconds
 	 */

--- a/source/src/Scalyr/ComplexExpressions/Parser.php
+++ b/source/src/Scalyr/ComplexExpressions/Parser.php
@@ -34,7 +34,7 @@ class Parser
 	 * @param string $fullVariableExpression
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws \Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException
 	 */
 	public static function ParseComplexExpression($expression, $start, $end, $buckets, &$fullVariableExpression)
 	{

--- a/source/src/Scalyr/Request/Exception/BadBucketsException.php
+++ b/source/src/Scalyr/Request/Exception/BadBucketsException.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: matt
+ * Date: 25/09/18
+ * Time: 11:22 AM
+ */
+
+namespace Adknown\ProxyScalyr\Scalyr\Request\Exception;
+
+
+use Adknown\ProxyScalyr\Scalyr\Request\Numeric;
+use Throwable;
+
+class BadBucketsException extends \Exception
+{
+	const MESSAGE_FORMAT = "attempted to use %d buckets. Scalyr allows between %d and %d buckets in their api calls.";
+
+	public function __construct(int $attemptedBuckets, string $appendedMessage = "", int $code = 0, Throwable $previous = null)
+	{
+		$message = sprintf(self::MESSAGE_FORMAT, $attemptedBuckets, Numeric::BUCKETS_MIN, Numeric::BUCKETS_MAX);
+		parent::__construct($message . $appendedMessage, $code, $previous);
+	}
+}

--- a/source/src/Scalyr/Request/Numeric.php
+++ b/source/src/Scalyr/Request/Numeric.php
@@ -8,8 +8,7 @@
 
 namespace Adknown\ProxyScalyr\Scalyr\Request;
 
-
-use Exception;
+use Adknown\ProxyScalyr\Scalyr\Request\Exception\BadBucketsException;
 
 class Numeric extends aBase
 {
@@ -27,6 +26,9 @@ class Numeric extends aBase
 	const FUNCTION_P999 = 'p999';
 	const FUNCTION_COUNT = 'count';
 	const FUNCTION_RATE = 'rate';
+
+	const BUCKETS_MIN = 1;
+	const BUCKETS_MAX = 5000;
 
 	/**
 	 * @var string
@@ -77,7 +79,7 @@ class Numeric extends aBase
 	 * @param int    $buckets   Number of numeric values to return. The time range is divided into this many equal slices. For instance, suppose you query a four-hour period, with buckets = 4. The query will return four numbers, each covering a one-hour period.
 	 * @param string $priority
 	 *
-	 * @throws Exception
+	 * @throws BadBucketsException
 	 */
 	public function __construct($filter, string $function, string $subjectField, string $startTime, string $endTime = "", int $buckets = 1, string $priority = self::PRIORITY_LOW)
 	{
@@ -95,7 +97,7 @@ class Numeric extends aBase
 	 * @param string $function
 	 * @param string $subjectField
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function setFunction($function, $subjectField)
 	{
@@ -132,17 +134,15 @@ class Numeric extends aBase
 				$this->function = self::FUNCTION_RATE;
 				break;
 			default:
-				throw new Exception("Unsupported function: $function");
+				throw new \Exception("Unsupported function: $function");
 		}
 	}
 
 	public function setBuckets(int $buckets)
 	{
-		$lower = 1;
-		$upper = 5000;
-		if($buckets < $lower || $buckets > $upper)
+		if($buckets < self::BUCKETS_MIN || $buckets > self::BUCKETS_MAX)
 		{
-			throw new Exception("Buckets must be between $lower and $upper. Attempted to set to $buckets.");
+			throw new BadBucketsException($buckets);
 		}
 		$this->buckets = $buckets;
 	}

--- a/source/src/Scalyr/Request/Numeric.php
+++ b/source/src/Scalyr/Request/Numeric.php
@@ -142,7 +142,7 @@ class Numeric extends aBase
 		$upper = 5000;
 		if($buckets < $lower || $buckets > $upper)
 		{
-			throw new Exception("Buckets must be between $lower and $upper");
+			throw new Exception("Buckets must be between $lower and $upper. Attempted to set to $buckets.");
 		}
 		$this->buckets = $buckets;
 	}

--- a/source/src/Utilities.php
+++ b/source/src/Utilities.php
@@ -13,41 +13,6 @@ class Utilities
 {
 	const DUMP_DIRECTORY = __DIR__ . '/../dump';
 
-	public static function WriteToFile($filename, $contents, $jsonEncode = false)
-	{
-
-		$now = new \DateTime('now', new \DateTimeZone('utc'));
-		$breakStr = "\n*******\n" . $now->format('Y-m-d-H-i-s') . "\n*******\n";
-
-		$filename .= ".txt";
-		$filename = str_replace(" ", "_", $filename);
-
-		if(is_array($contents))
-		{
-			if($jsonEncode === true)
-			{
-				$contents = json_encode($contents);
-			}
-			else
-			{
-				$realContents = "";
-				foreach($contents as $key => $value)
-				{
-					$realContents .= "$key: " . print_r($value, true) . "\n";
-				}
-				$contents = $realContents;
-			}
-		}
-		else
-		{
-			if(is_string($contents) !== true)
-			{
-				$contents = print_r($contents, true);
-			}
-		}
-		file_put_contents(self::DUMP_DIRECTORY . "/$filename", $breakStr . $contents, FILE_APPEND);
-	}
-
 	// Gets the user's user agent string if it exists as a server variable
 	public static function GetUserAgent()
 	{


### PR DESCRIPTION
## Context

Users should be able to view a Scalyr time-series in fixed intervals, eg. grouping data by minute/hour/day. The remainder of the most recent interval should be accounted for (eg. the first 13 minutes of the most recent hour should be shown as its own data point).

## Objective

* Add support for fixed-intervals
