### PR TITLE
Add Native Alerting to the Grafana Scalyr Datasource Plugin

### DIFF
--- a/source/src/Grafana/Request/Range.php
+++ b/source/src/Grafana/Request/Range.php
@@ -21,6 +21,11 @@ class Range
 	 */
 	public function GetFromAsTimestamp()
 	{
+		//Alerts don't pass time as a string, they pass as unix ms
+		if(!strtotime($this->from))
+		{
+			return $this->from;
+		}
 		return strtotime($this->from);
 	}
 
@@ -31,6 +36,11 @@ class Range
 	 */
 	public function GetToAsTimestamp()
 	{
+		//Alerts don't pass time as a string, they pass as unix ms
+		if(!strtotime($this->to))
+		{
+			return $this->to;
+		}
 		return strtotime($this->to);
 	}
 


### PR DESCRIPTION
- changed timestamp thing to use ms when available as alerts only send time in ms
- for compatibility with https://github.com/AdknownInc/grafana-scalyr-datasource-plugin/pull/14